### PR TITLE
Add accounts-backend service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,12 +1096,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "tub"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bca43faba247bc76eb1d6c1b8b561e4a1c5bdd427cc3d7a007faabea75c683a"
+dependencies = [
+ "crossbeam-queue",
+ "tokio",
+]
+
+[[package]]
 name = "twote-api"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "schemas",
  "tokio",
  "tonic",
+ "tub",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "accounts-backend"
+version = "0.1.0"
+dependencies = [
+ "schemas",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ prost = "0.12.0"
 rand = { version = "0.8.5" }
 prost-types = { version = "0.12" }
 yew = { version = "0.20.0", features = ["csr"] }
+tub = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "schemas",
     "twote-api",
+    "accounts-backend"
 ]
 
 resolver = "2"

--- a/accounts-backend/Cargo.toml
+++ b/accounts-backend/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "accounts-backend"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+schemas = { path = "../schemas" }
+tonic.workspace=true
+tokio.workspace=true

--- a/accounts-backend/src/main.rs
+++ b/accounts-backend/src/main.rs
@@ -1,0 +1,19 @@
+use crate::service::login::LoginServiceImpl;
+use schemas::login::login_service_server::LoginServiceServer;
+use tonic::transport::Server;
+
+mod service;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr = "127.0.0.1:50052".parse()?;
+
+    println!("Running on {}", addr);
+
+    Server::builder()
+        .add_service(LoginServiceServer::new(LoginServiceImpl))
+        .serve(addr)
+        .await?;
+
+    Ok(())
+}

--- a/accounts-backend/src/service/login.rs
+++ b/accounts-backend/src/service/login.rs
@@ -1,0 +1,20 @@
+use tonic::{Code, Request, Response, Status};
+
+use schemas::login::login_service_server::LoginService;
+use schemas::login::{LoginRequest, LoginResponse};
+
+pub struct LoginServiceImpl;
+
+#[tonic::async_trait]
+impl LoginService for LoginServiceImpl {
+    async fn login(
+        &self,
+        _request: Request<LoginRequest>,
+    ) -> Result<Response<LoginResponse>, Status> {
+        let message = format!(
+            "oops! not implemented! Sorry {}!",
+            _request.into_inner().username
+        );
+        Err(Status::new(Code::Aborted, message))
+    }
+}

--- a/accounts-backend/src/service/mod.rs
+++ b/accounts-backend/src/service/mod.rs
@@ -1,0 +1,1 @@
+pub mod login;

--- a/twote-api/Cargo.toml
+++ b/twote-api/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 schemas = { path = "../schemas" }
 tonic.workspace=true
 tokio.workspace=true
+tub.workspace=true
+anyhow.workspace=true

--- a/twote-api/src/main.rs
+++ b/twote-api/src/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Server::builder()
         .add_service(HelloServiceServer::new(HelloServiceImpl))
-        .add_service(LoginServiceServer::new(LoginServiceImpl))
+        .add_service(LoginServiceServer::new(LoginServiceImpl::new().await?))
         .serve(addr)
         .await?;
 

--- a/twote-api/src/service/login.rs
+++ b/twote-api/src/service/login.rs
@@ -1,5 +1,6 @@
 use tonic::{Code, Request, Response, Status};
 
+use schemas::login::login_service_client::LoginServiceClient;
 use schemas::login::login_service_server::LoginService;
 use schemas::login::{LoginRequest, LoginResponse};
 
@@ -9,9 +10,12 @@ pub struct LoginServiceImpl;
 impl LoginService for LoginServiceImpl {
     async fn login(
         &self,
-        _request: Request<LoginRequest>,
+        request: Request<LoginRequest>,
     ) -> Result<Response<LoginResponse>, Status> {
-        let message = format!("not implemented. Sorry {}!", _request.into_inner().username);
-        Err(Status::new(Code::Aborted, message))
+        // TODO: add a LoginServiceImpl constructor that creates a LoginServiceClient
+        match LoginServiceClient::connect("http://localhost:50052").await {
+            Ok(mut client) => client.login(request).await,
+            Err(err) => Err(Status::new(Code::Internal, err.to_string())),
+        }
     }
 }


### PR DESCRIPTION
## What

Add `accounts-backend` service

## Why

This service will be used to handle the accounts database interactions

## How

To create this service, I ran:

```
cargo new accounts-backend
```

`cargo new` is a command which creates cargo crates. `accounts-backend` is the name of the crate.

I then added it to the project's `Cargo.toml` workspace, and updated the service's `Cargo.toml` to pull in the required dependencies.

I then modified `twote-api` to forward all `LoginRequest`s to `accounts-backend` via `LoginServiceClient`

## Testing

<img width="1728" alt="image" src="https://github.com/wcygan/twote/assets/32029716/ea72bcef-c413-4fe4-82e8-3a10c9894d70">
