### PR TITLE
Add tracing logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,8 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-health",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -464,6 +466,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +544,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +577,12 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -848,6 +872,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +952,16 @@ dependencies = [
  "redox_syscall",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1101,6 +1144,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1128,6 +1197,8 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-health",
+ "tracing",
+ "tracing-subscriber",
  "tub",
 ]
 
@@ -1136,6 +1207,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "want"

--- a/accounts-backend/Cargo.toml
+++ b/accounts-backend/Cargo.toml
@@ -6,6 +6,8 @@ license = "MIT"
 
 [dependencies]
 schemas = { path = "../schemas" }
+tracing.workspace=true
+tracing-subscriber.workspace=true
 tonic.workspace=true
 tonic-health.workspace=true
 tokio.workspace=true

--- a/accounts-backend/src/main.rs
+++ b/accounts-backend/src/main.rs
@@ -8,6 +8,9 @@ const ADDR: &str = "0.0.0.0:8082";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
     let addr = ADDR.parse()?;
 
     // Create the services

--- a/accounts-backend/src/service/login.rs
+++ b/accounts-backend/src/service/login.rs
@@ -1,5 +1,5 @@
 use tonic::{Code, Request, Response, Status};
-use tracing::{info};
+use tracing::info;
 
 use schemas::login::login_service_server::LoginService;
 use schemas::login::{LoginRequest, LoginResponse};

--- a/accounts-backend/src/service/login.rs
+++ b/accounts-backend/src/service/login.rs
@@ -1,5 +1,5 @@
 use tonic::{Code, Request, Response, Status};
-use tracing::{event, info};
+use tracing::{info};
 
 use schemas::login::login_service_server::LoginService;
 use schemas::login::{LoginRequest, LoginResponse};
@@ -13,7 +13,7 @@ impl LoginService for LoginServiceImpl {
         &self,
         request: Request<LoginRequest>,
     ) -> Result<Response<LoginResponse>, Status> {
-        info!("accounts-backend/login");
+        info!("Processing LoginRequest");
         let message = format!(
             "oops! not implemented! Sorry {}!",
             request.into_inner().username

--- a/accounts-backend/src/service/login.rs
+++ b/accounts-backend/src/service/login.rs
@@ -1,4 +1,5 @@
 use tonic::{Code, Request, Response, Status};
+use tracing::{event, info};
 
 use schemas::login::login_service_server::LoginService;
 use schemas::login::{LoginRequest, LoginResponse};
@@ -7,10 +8,12 @@ pub struct LoginServiceImpl;
 
 #[tonic::async_trait]
 impl LoginService for LoginServiceImpl {
+    #[tracing::instrument(skip(self))]
     async fn login(
         &self,
         request: Request<LoginRequest>,
     ) -> Result<Response<LoginResponse>, Status> {
+        info!("accounts-backend/login");
         let message = format!(
             "oops! not implemented! Sorry {}!",
             request.into_inner().username

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,7 +2,6 @@
 name = "common"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = "MIT"
 
 [dependencies]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -21,11 +21,7 @@ impl Service {
     }
 
     pub fn addr(&self) -> String {
-        match self {
-            _ => {
-                format!("https://{}:{}", self.name(), self.port())
-            }
-        }
+        format!("https://{}:{}", self.name(), self.port())
     }
 
     pub fn socket_addr(&self) -> SocketAddr {

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -35,6 +35,13 @@ static_resources:
                         expose_headers: custom-header-1,grpc-status,grpc-message
                         max_age: "1728000"
                 http_filters:
+                  - name: envoy.filters.http.lua
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                      inline_code: |
+                        function envoy_on_request(request_handle)
+                          request_handle:headers():add("x-request-id", require("uuid").generate_v4())
+                        end
                   - name: envoy.filters.http.grpc_web
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -35,13 +35,6 @@ static_resources:
                         expose_headers: custom-header-1,grpc-status,grpc-message
                         max_age: "1728000"
                 http_filters:
-                  - name: envoy.filters.http.lua
-                    typed_config:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-                      inline_code: |
-                        function envoy_on_request(request_handle)
-                          request_handle:headers():add("x-request-id", require("uuid").generate_v4())
-                        end
                   - name: envoy.filters.http.grpc_web
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb

--- a/twote-api/Cargo.toml
+++ b/twote-api/Cargo.toml
@@ -6,6 +6,8 @@ license = "MIT"
 
 [dependencies]
 schemas = { path = "../schemas" }
+tracing.workspace=true
+tracing-subscriber.workspace=true
 tonic.workspace=true
 tonic-health.workspace=true
 tokio.workspace=true

--- a/twote-api/src/main.rs
+++ b/twote-api/src/main.rs
@@ -12,6 +12,9 @@ const ADDR: &str = "0.0.0.0:8081";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
     let addr = ADDR.parse()?;
 
     // Create the services

--- a/twote-api/src/service/hello.rs
+++ b/twote-api/src/service/hello.rs
@@ -1,4 +1,5 @@
 use tonic::{Request, Response, Status};
+use tracing::info;
 
 use schemas::hello::{hello_service_server::HelloService, HelloReply, HelloRequest};
 
@@ -6,10 +7,12 @@ pub struct HelloServiceImpl;
 
 #[tonic::async_trait]
 impl HelloService for HelloServiceImpl {
+    #[tracing::instrument(skip(self))]
     async fn say_hello(
         &self,
         request: Request<HelloRequest>,
     ) -> Result<Response<HelloReply>, Status> {
+        info!("twote-api/hello");
         let greeting = request.into_inner().greeting;
 
         let reply = HelloReply {

--- a/twote-api/src/service/hello.rs
+++ b/twote-api/src/service/hello.rs
@@ -12,7 +12,7 @@ impl HelloService for HelloServiceImpl {
         &self,
         request: Request<HelloRequest>,
     ) -> Result<Response<HelloReply>, Status> {
-        info!("twote-api/hello");
+        info!("Processing HelloRequest");
         let greeting = request.into_inner().greeting;
 
         let reply = HelloReply {

--- a/twote-api/src/service/login.rs
+++ b/twote-api/src/service/login.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use tonic::transport::Channel;
 use tonic::{Request, Response, Status};
+use tracing::info;
 use tub::Pool;
 
 use schemas::login::login_service_client::LoginServiceClient;
@@ -22,10 +23,12 @@ impl LoginServiceImpl {
 
 #[tonic::async_trait]
 impl LoginService for LoginServiceImpl {
+    #[tracing::instrument(skip(self))]
     async fn login(
         &self,
         request: Request<LoginRequest>,
     ) -> Result<Response<LoginResponse>, Status> {
+        info!("twote-api/login");
         let mut login_service_client = self.login_service_clients.acquire().await;
         login_service_client.login(request).await
     }

--- a/twote-api/src/service/login.rs
+++ b/twote-api/src/service/login.rs
@@ -28,7 +28,7 @@ impl LoginService for LoginServiceImpl {
         &self,
         request: Request<LoginRequest>,
     ) -> Result<Response<LoginResponse>, Status> {
-        info!("twote-api/login");
+        info!("Processing LoginRequest");
         let mut login_service_client = self.login_service_clients.acquire().await;
         login_service_client.login(request).await
     }


### PR DESCRIPTION
Add [tracing](https://docs.rs/tracing) logger

What's especially cool about this is that [Envoy](https://www.envoyproxy.io/) applies a requestId to the payload automatically. This means that it's possible to forward the `x-request-id` to every application who a gRPC request is sent to, allowing you to trace requests throughout the system.

```
"x-request-id": "a21f27dc-748a-472f-8c6c-9b32b4761a32"
```

## Testing

```
docker-compose up -d
```

<img width="1728" alt="image" src="https://github.com/wcygan/twote/assets/32029716/079fa69f-52b5-4182-b36c-88075d5ad041">
